### PR TITLE
Brandify the styling for short-term aesthetic improvements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,13 @@
 
 <head>
-    <link rel="icon" 
-    type="image/png" 
+    <link rel="icon"
+    type="image/png"
     href="OrgLogo.png">
 	<link rel="stylesheet" href="mainpage.css"></link>
+  <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
 	<title>LGBTQ+ of FIRST Pin Tracker</title>
 </head>
-<body style="background-color:black">
+<body>
 <div class="header">
 <h1>LGBTQ+ of FIRST Live Pin Tracker <div class="beta">BETA</div></h1></div>
 <table class="main_table">

--- a/mainpage.css
+++ b/mainpage.css
@@ -1,29 +1,34 @@
+
+body {
+	background: #2D3142;
+}
+
 .header {
 	color: white;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	font-size: 30px;
 	text-align: center;
 	display: inline-block;
 }
 
 .beta {
-    color: white;
-	font-family: sans-serif;
+  color: white;
+	font-family: 'Montserrat', sans-serif;
 	font-size: 55px;
 	text-align: right;
 	display: inline-block;
-	background-color: blue;
+	background-color: #2196F3;
 }
 
 .main_table {
 	color: white;
-	border: 4px blue solid;
+	border: 3px white solid;
 }
 
 .table_element {
 	font-size: 30px;
 	color: white;
-	border-bottom: 1px solid white;
+	border: 1px solid white;
 	text-align: center;
 	font-family: sans-serif;
 }
@@ -33,58 +38,57 @@
 }
 
 .frc {
-	background-color: blue;
+	background-color: #2196F3;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
 }
 
 .ftc {
-	background-color: orange;
+	background-color: #FFCC80;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
 }
 
 .staff {
-	background-color: purple;
+	background-color: #B39DDB;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
 }
 
 .check {
-	background-color: green;
+	background-color: #81C784;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
 }
 
 .caution {
-	background-color: yellow;
+	background-color: #FFE082;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
-	color: black;
 }
 
 .out {
-	background-color: red;
+	background-color: #E57373;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
 }
 
 .not_enrolled {
-	background-color: black;
+	background: #2D3142;
 	font-size: 30px;
-	font-family: sans-serif;
+	font-family: 'Montserrat', sans-serif;
 	text-align: center;
 	padding: 20px;
 }


### PR DESCRIPTION
Made the following edits to (mostly) comply with organizational branding guidelines:
1. Added Montserrat as a Google-hosted webfont to HTML head;
2. Changed all generic sans-serif styling in CSS file to use Montserrat, and use system's san-serif when unavailable;
3. Changed default CSS variable color-names to corresponding accent color tint values per Branding document;
4. Altered pixel width of table border by -1;
5. Changed page background from black to a dark/gunmetal gray not listed in Branding document due to the grays in said document looking gross in context.